### PR TITLE
brew formula for hyperdex 1.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,7 @@ Homebrew tap for HyperDex.
 
 Optional client bindings can be individually selected with
 `brew install --with-java-bindings --with-python-bindings --with-ruby-bindings hyperdex`
+
+
+Enabling bindings for ycsb:
+`CLASSPATH=<ycsb folder>/core/lib/core-<ycsb-version>.jar brew install --with-java-bindings --with-enable-ycsb hyperdex`

--- a/README.md
+++ b/README.md
@@ -2,34 +2,7 @@ Homebrew tap for HyperDex.
 
 ## Installation
 
-#Using formula from the official repository
-
 `brew tap HyperDex/hyperdex && brew install hyperdex.`
 
 Optional client bindings can be individually selected with
 `brew install --with-java-bindings --with-python-bindings --with-ruby-bindings hyperdex`
-
-## Using formula from this fork (HyperDex 1.6.0)
-
-```
-brew tap dayasakti/hyperdex
-brew install hyperdex
-```
-
-Optional client bindings can be individually selected with
-`brew install --with-java-bindings --with-python-bindings --with-ruby-bindings hyperdex`
-
-
-## java binding hacks on macosx 10.7.5
-(only when you install JDK from oracle)
-
-Assuming that you are installing jdk1.7.0_45. Then you may need to create
-a symlink below if you enable --with-java-bindings
-
-```
-sudo ln -sf /Library/Java/JavaVirtualMachines/jdk1.7.0_45.jdk/Contents/Home/include  .
-cd /Library/Java/JavaVirtualMachines/jdk1.7.0_45.jdk/Contents/Home/include
-sudo ln -sf darwin/jni_md.h .
-sudo ln -sf darwin/jawt_md.h .
-```
-

--- a/README.md
+++ b/README.md
@@ -8,6 +8,6 @@ Optional client bindings can be individually selected with
 `brew install --with-java-bindings --with-python-bindings --with-ruby-bindings hyperdex`
 
 
-Enabling bindings for ycsb
+Enabling bindings for ycsb:
 
 `CLASSPATH=<ycsb folder>/core/lib/core-<ycsb-version>.jar brew install --with-java-bindings --with-enable-ycsb hyperdex`

--- a/README.md
+++ b/README.md
@@ -2,7 +2,27 @@ Homebrew tap for HyperDex.
 
 ## Installation
 
+#Using formula from the official repository
+
 `brew tap HyperDex/hyperdex && brew install hyperdex.`
 
 Optional client bindings can be individually selected with
 `brew install --with-java-bindings --with-python-bindings --with-ruby-bindings hyperdex`
+
+## Using formula from this fork
+
+`brew tap dayasakti/hyperdex && brew install hyperdex.`
+
+## java binding hacks on macosx 10.7.5
+(only when you install JDK from oracle)
+
+Assuming that you are installing jdk1.7.0_45. Then you may need to create
+a symlink below if you enable --with-java-bindings
+
+```
+sudo ln -sf /Library/Java/JavaVirtualMachines/jdk1.7.0_45.jdk/Contents/Home/include  .
+cd /Library/Java/JavaVirtualMachines/jdk1.7.0_45.jdk/Contents/Home/include
+sudo ln -sf darwin/jni_md.h .
+sudo ln -sf darwin/jawt_md.h .
+```
+

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Homebrew tap for HyperDex.
 Optional client bindings can be individually selected with
 `brew install --with-java-bindings --with-python-bindings --with-ruby-bindings hyperdex`
 
-## Using formula from this fork
+## Using formula from this fork (HyperDex 1.6.0)
 
 `brew tap dayasakti/hyperdex && brew install hyperdex.`
 

--- a/README.md
+++ b/README.md
@@ -8,5 +8,6 @@ Optional client bindings can be individually selected with
 `brew install --with-java-bindings --with-python-bindings --with-ruby-bindings hyperdex`
 
 
-Enabling bindings for ycsb:
+Enabling bindings for ycsb
+
 `CLASSPATH=<ycsb folder>/core/lib/core-<ycsb-version>.jar brew install --with-java-bindings --with-enable-ycsb hyperdex`

--- a/README.md
+++ b/README.md
@@ -11,7 +11,14 @@ Optional client bindings can be individually selected with
 
 ## Using formula from this fork (HyperDex 1.6.0)
 
-`brew tap dayasakti/hyperdex && brew install hyperdex.`
+```
+brew tap dayasakti/hyperdex
+brew install hyperdex
+```
+
+Optional client bindings can be individually selected with
+`brew install --with-java-bindings --with-python-bindings --with-ruby-bindings hyperdex`
+
 
 ## java binding hacks on macosx 10.7.5
 (only when you install JDK from oracle)

--- a/hyperdex.rb
+++ b/hyperdex.rb
@@ -2,8 +2,8 @@ require 'formula'
 
 class Hyperdex < Formula
   homepage 'http://hyperdex.org'
-  url 'http://hyperdex.org/src/hyperdex-1.4.4.tar.gz'
-  sha1 'c5b126fc7862de66eab54fa5ef3c7cbb84b2bc9b'
+  url 'http://hyperdex.org/src/hyperdex-1.6.0.tar.gz'
+  sha1 'b019a2d1fc3e25a140b729d4392f7c07dd0cfcc2'
 
   depends_on 'autoconf'
   depends_on 'automake'

--- a/hyperdex.rb
+++ b/hyperdex.rb
@@ -20,6 +20,7 @@ class Hyperdex < Formula
   depends_on 'busybee'
   depends_on 'hyperleveldb'
   depends_on 'replicant'
+  depends_on 'libmacaroons'
 
   option 'with-python-bindings', "Builds and installs Python client bindings"
   option 'with-java-bindings', "Builds and installs Java client bindings"

--- a/hyperdex.rb
+++ b/hyperdex.rb
@@ -21,6 +21,7 @@ class Hyperdex < Formula
   depends_on 'hyperleveldb'
   depends_on 'replicant'
   depends_on 'libmacaroons'
+  depends_on 'libtreadstone'
 
   option 'with-python-bindings', "Builds and installs Python client bindings"
   option 'with-java-bindings', "Builds and installs Java client bindings"

--- a/hyperdex.rb
+++ b/hyperdex.rb
@@ -26,6 +26,7 @@ class Hyperdex < Formula
   option 'with-python-bindings', "Builds and installs Python client bindings"
   option 'with-java-bindings', "Builds and installs Java client bindings"
   option 'with-ruby-bindings', "Builds and installs Ruby client bindings"
+  option 'with-enable-ycsb', "Enable the Yahoo Cloud Serving Benchmark"
 
   def patches
     DATA
@@ -37,6 +38,7 @@ class Hyperdex < Formula
     args << "--enable-java-bindings" if build.with? "java-bindings"
     args << "--enable-python-bindings" if build.with? "python-bindings"
     args << "--enable-ruby-bindings" if build.with? "ruby-bindings"
+    args << "--enable-ycsb" if build.with? "enable-ycsb"
     
     system "./configure", "--prefix=#{prefix}", *args
     system "make"

--- a/hyperleveldb.rb
+++ b/hyperleveldb.rb
@@ -2,8 +2,8 @@ require 'formula'
 
 class Hyperleveldb < Formula
   homepage 'http://hyperdex.org'
-  url 'http://hyperdex.org/src/hyperleveldb-1.2.1.tar.gz'
-  sha1 'fc43412dbc2cafc7cee8fd47b3e12a84c2833ec4'
+  url 'http://hyperdex.org/src/hyperleveldb-1.2.2.tar.gz'
+  sha1 '5cc2694f5f13388a28e17cd65a6b650ebc3d39a4'
 
   def install
     ENV['PKG_CONFIG_PATH']="#{HOMEBREW_PREFIX}/lib/pkgconfig"

--- a/libe.rb
+++ b/libe.rb
@@ -2,8 +2,8 @@ require 'formula'
 
 class Libe < Formula
   homepage 'http://hyperdex.org'
-  url 'http://hyperdex.org/src/libe-0.8.1.tar.gz'
-  sha1 '95c42531d4834b5eb801694b6929f831b76a24f0'
+  url 'http://hyperdex.org/src/libe-0.9.0.tar.gz'
+  sha1 '30b6273a1f374035dfbe770bdee36ac0b30a24c4'
 
   depends_on 'autoconf'
   depends_on 'automake'

--- a/libmacaroons.rb
+++ b/libmacaroons.rb
@@ -1,0 +1,22 @@
+require 'formula'
+
+class Replicant < Formula
+  homepage 'http://hyperdex.org'
+  url 'http://hyperdex.org/src/libmacaroons-0.2.0.tar.gz'
+  sha1 'e8f3dfdb322febdeff03c0e71c3ed9518711f629'
+
+  depends_on 'autoconf'
+  depends_on 'automake'
+  depends_on 'autoconf-archive'
+  depends_on 'libtool'
+  depends_on 'pkg-config'
+
+  depends_on 'libsodium'
+
+  def install
+    ENV['PKG_CONFIG_PATH']="#{HOMEBREW_PREFIX}/lib/pkgconfig"
+    system "./configure", "--prefix=#{prefix}"
+    system "make"
+    system "make install"
+  end
+end

--- a/libmacaroons.rb
+++ b/libmacaroons.rb
@@ -1,6 +1,6 @@
 require 'formula'
 
-class Replicant < Formula
+class Libmacaroons < Formula
   homepage 'http://hyperdex.org'
   url 'http://hyperdex.org/src/libmacaroons-0.2.0.tar.gz'
   sha1 'e8f3dfdb322febdeff03c0e71c3ed9518711f629'

--- a/libtreadstone.rb
+++ b/libtreadstone.rb
@@ -13,6 +13,10 @@ class Libtreadstone < Formula
 
   depends_on 'libpo6'
 
+  def patches
+    DATA
+  end
+  
   def install
     ENV['PKG_CONFIG_PATH']="#{HOMEBREW_PREFIX}/lib/pkgconfig"
     system "./configure", "--prefix=#{prefix}"
@@ -20,3 +24,17 @@ class Libtreadstone < Formula
     system "make install"
   end
 end
+__END__
+diff --git a/treadstone.cc b/treadstone.cc
+index f4f651b..cf2b884 100644
+--- a/treadstone.cc
++++ b/treadstone.cc
+@@ -1805,7 +1805,7 @@ treadstone_transformer :: parse_array(const treadstone::pa
+     {
+         const unsigned char* const elem_start = tmp;
+         const unsigned char* elem_tmp = NULL;
+-        size_t elem_sz;
++        uint64_t elem_sz;
+
+         switch (*elem_start)
+         {

--- a/libtreadstone.rb
+++ b/libtreadstone.rb
@@ -1,17 +1,20 @@
 require 'formula'
 
-class Libpo6 < Formula
+class Libtreadstone < Formula
   homepage 'http://hyperdex.org'
-  url 'http://hyperdex.org/src/libpo6-0.6.0.tar.gz'
-  sha1 '4bed4124daf33acba0e527c4dc59ccc63c8bbde0'
+  url 'http://hyperdex.org/src/libtreadstone-0.1.0.tar.gz'
+  sha1 '5e34d8c67a2e7c1b3c5a6ade4c5141372297fb0d'
 
   depends_on 'autoconf'
   depends_on 'automake'
   depends_on 'autoconf-archive'
   depends_on 'libtool'
+  depends_on 'pkg-config'
+
+  depends_on 'libpo6'
 
   def install
-    system "autoreconf", "-i"
+    ENV['PKG_CONFIG_PATH']="#{HOMEBREW_PREFIX}/lib/pkgconfig"
     system "./configure", "--prefix=#{prefix}"
     system "make"
     system "make install"

--- a/libtreadstone.rb
+++ b/libtreadstone.rb
@@ -16,7 +16,7 @@ class Libtreadstone < Formula
   def patches
     DATA
   end
-  
+
   def install
     ENV['PKG_CONFIG_PATH']="#{HOMEBREW_PREFIX}/lib/pkgconfig"
     system "./configure", "--prefix=#{prefix}"

--- a/replicant.rb
+++ b/replicant.rb
@@ -2,8 +2,8 @@ require 'formula'
 
 class Replicant < Formula
   homepage 'http://hyperdex.org'
-  url 'http://hyperdex.org/src/replicant-0.6.3.tar.gz'
-  sha1 'e3677d6998623db3fdba4ac834eb69e8be6852c2'
+  url 'http://hyperdex.org/src/replicant-0.6.4.tar.gz'
+  sha1 'bc2527c31ef4671859926fc31b6eb80b9011026e'
 
   depends_on 'autoconf'
   depends_on 'automake'


### PR DESCRIPTION
- Got brew to install hyperdex 1.6.0 on  MacOSX 10.7.5 and 10.10.2
- using 'Installing From Source' (http://hyperdex.org/doc/latest/InstallingHyperDex/#x4-180008) as a guideline
