### PR TITLE
Update to Hyperdex 1.8.1

### DIFF
--- a/busybee.rb
+++ b/busybee.rb
@@ -2,8 +2,8 @@ require 'formula'
 
 class Busybee < Formula
   homepage 'http://hyperdex.org'
-  url 'http://hyperdex.org/src/busybee-0.5.2.tar.gz'
-  sha1 'e50b4a679791195f079e775ca06bf728711d0d72'
+  url 'http://hyperdex.org/src/busybee-0.7.0.tar.gz'
+  sha1 '39e9e046fbe48ab8cdf1cf13efb234bf4fb09429'
 
   depends_on 'autoconf'
   depends_on 'automake'

--- a/hyperdex.rb
+++ b/hyperdex.rb
@@ -2,8 +2,8 @@ require 'formula'
 
 class Hyperdex < Formula
   homepage 'http://hyperdex.org'
-  url 'http://hyperdex.org/src/hyperdex-1.4.4.tar.gz'
-  sha1 'c5b126fc7862de66eab54fa5ef3c7cbb84b2bc9b'
+  url 'http://hyperdex.org/src/hyperdex-1.8.1.tar.gz'
+  sha1 '70b346b92bf8311145f94a3429f72b51012586f1'
 
   depends_on 'autoconf'
   depends_on 'automake'

--- a/hyperleveldb.rb
+++ b/hyperleveldb.rb
@@ -2,8 +2,8 @@ require 'formula'
 
 class Hyperleveldb < Formula
   homepage 'http://hyperdex.org'
-  url 'http://hyperdex.org/src/hyperleveldb-1.2.1.tar.gz'
-  sha1 'fc43412dbc2cafc7cee8fd47b3e12a84c2833ec4'
+  url 'http://hyperdex.org/src/hyperleveldb-1.2.2.tar.gz'
+  sha1 '5cc2694f5f13388a28e17cd65a6b650ebc3d39a4'
 
   def install
     ENV['PKG_CONFIG_PATH']="#{HOMEBREW_PREFIX}/lib/pkgconfig"

--- a/libe.rb
+++ b/libe.rb
@@ -2,8 +2,8 @@ require 'formula'
 
 class Libe < Formula
   homepage 'http://hyperdex.org'
-  url 'http://hyperdex.org/src/libe-0.8.1.tar.gz'
-  sha1 '95c42531d4834b5eb801694b6929f831b76a24f0'
+  url 'http://hyperdex.org/src/libe-0.9.0.tar.gz'
+  sha1 '30b6273a1f374035dfbe770bdee36ac0b30a24c4'
 
   depends_on 'autoconf'
   depends_on 'automake'

--- a/libpo6.rb
+++ b/libpo6.rb
@@ -2,8 +2,8 @@ require 'formula'
 
 class Libpo6 < Formula
   homepage 'http://hyperdex.org'
-  url 'http://hyperdex.org/src/libpo6-0.5.2.tar.gz'
-  sha1 'dcbce34fe3f1032381e125204168dac71d159ec3'
+  url 'http://hyperdex.org/src/libpo6-0.8.0.tar.gz'
+  sha1 'f3cb7009d0379ac2da9f3800991c86af584558ee'
 
   depends_on 'autoconf'
   depends_on 'automake'

--- a/replicant.rb
+++ b/replicant.rb
@@ -2,8 +2,8 @@ require 'formula'
 
 class Replicant < Formula
   homepage 'http://hyperdex.org'
-  url 'http://hyperdex.org/src/replicant-0.6.3.tar.gz'
-  sha1 'e3677d6998623db3fdba4ac834eb69e8be6852c2'
+  url 'http://hyperdex.org/src/replicant-0.8.1.tar.gz'
+  sha1 'f3e8c97b448a75f1bbd121ce279a6cc60bec2900'
 
   depends_on 'autoconf'
   depends_on 'automake'


### PR DESCRIPTION
This updates all Homebrew formulas to 1.8.1 and its deps. Unfortunately this won't yet work, as `libpo6` 0.8.0 [doesn't compile on OS X](https://github.com/rescrv/po6/issues/9) at the moment.
